### PR TITLE
style: tidy R scripts

### DIFF
--- a/R/linear_regression_outlier_analysis.R
+++ b/R/linear_regression_outlier_analysis.R
@@ -137,10 +137,10 @@ grafico_sem_outliers <- ggplot(data = dados_sem_outliers, aes(x = Age, y = AGB))
 
 grafico_comparativo <- ggplot() +
   geom_point(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"), size = 2) +
-  geom_smooth(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"), 
+  geom_smooth(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"),
               method = "lm", se = FALSE) +
   geom_point(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"), size = 2) +
-  geom_smooth(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"), 
+  geom_smooth(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"),
               method = "lm", se = FALSE, linetype = "dashed") +
   labs(
     title = "Comparação de Modelos de Regressão Linear Simples: Com e Sem Outliers",
@@ -275,10 +275,10 @@ grafico_sem_outliers <- ggplot(data = dados_sem_outliers, aes(x = Age, y = AGB))
 
 grafico_comparativo <- ggplot() +
   geom_point(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"), size = 2) +
-  geom_smooth(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"), 
+  geom_smooth(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"),
               method = "lm", se = FALSE) +
   geom_point(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"), size = 2) +
-  geom_smooth(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"), 
+  geom_smooth(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"),
               method = "lm", se = FALSE, linetype = "dashed") +
   labs(
     title = "Comparação de Modelos de Regressão Linear Múltipla: Com e Sem Outliers",

--- a/R/linear_regression_outlier_analysis_subset.R
+++ b/R/linear_regression_outlier_analysis_subset.R
@@ -293,10 +293,10 @@ grafico_sem_outliers <- ggplot(data = dados_sem_outliers, aes(x = Age, y = AGB))
 
 grafico_comparativo <- ggplot() +
   geom_point(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"), size = 2) +
-  geom_smooth(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"), 
+  geom_smooth(data = dados_floresta, aes(x = Age, y = AGB, color = "Com Outliers"),
               method = "lm", se = FALSE) +
   geom_point(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"), size = 2) +
-  geom_smooth(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"), 
+  geom_smooth(data = dados_sem_outliers, aes(x = Age, y = AGB, color = "Sem Outliers"),
               method = "lm", se = FALSE, linetype = "dashed") +
   labs(
     title = "Comparação de Modelos de Regressão Linear Múltipla: Com e Sem Outliers",

--- a/R/regression_analyses.R
+++ b/R/regression_analyses.R
@@ -29,7 +29,7 @@ forest_data[forest_data == -9999] <- NA
 run_regression_analysis <- function(data, formula, model_name) {
   # Determinando o tipo de modelo com base no nome
   model_type <- unlist(strsplit(model_name, "_"))[1]
-  
+
   # Ajustando o modelo de acordo com o tipo
   model <- switch(model_type,
                   "Linear" = lm(formula, data = data),
@@ -42,7 +42,7 @@ run_regression_analysis <- function(data, formula, model_name) {
                           start = start_vals,
                           algorithm = "port",
                           control = nls.control(maxiter = 1000, warnOnly = TRUE)),
-                      error = function(e) { 
+                      error = function(e) {
                         message("Erro no modelo Gompertz: ", e$message)
                         return(NULL)
                       }
@@ -57,100 +57,100 @@ run_regression_analysis <- function(data, formula, model_name) {
                           algorithm = "port",
                           lower = c(BETA = 0, A = 0, THETA = 0.01),
                           control = nls.control(maxiter = 1000, warnOnly = TRUE)),
-                      error = function(e) { 
+                      error = function(e) {
                         message("Erro no modelo Schnute: ", e$message)
                         return(NULL)
                       }
                     )
                   }
   )
-  
+
   # Verificando se o modelo foi Ajustada corretamente
   if (is.null(model)) {
     return(NULL)
   }
-  
+
   # Mostrando um resumo do modelo
   print(summary(model))
-  
+
   # Criando uma lista para armazenar os diagnósticos
   diagnostics <- list(summary = summary(model))
-  
+
   if (model_type %in% c("Linear", "Multipla")) {
     # Verificando possíveis outliers usando o teste de Bonferroni
     diagnostics$outlier_test <- tryCatch(
       outlierTest(model),
-      error = function(e) { 
+      error = function(e) {
         message("Erro no teste de outliers para ", model_name, ": ", e$message)
         return(NULL)
       }
     )
-    
+
     if (!is.null(diagnostics$outlier_test)) {
       print(diagnostics$outlier_test)
     }
-    
+
     # Calculando a distância de Cook
     diagnostics$cooksd <- cooks.distance(model)
-    
+
     # Plotando a distância de Cook
     plot(diagnostics$cooksd, type = "h", main = paste("Distância de Cook -", model_name), ylab = "Distância de Cook")
     abline(h = 4 / nrow(data), col = "red")
-    
+
     # Calculando os valores de alavancagem
     diagnostics$hat_values <- hatvalues(model)
-    
+
     # Plotando os valores de alavancagem
     plot(diagnostics$hat_values, type = "h", main = paste("Valores de Alavancagem -", model_name), ylab = "Valores de Hat")
     abline(h = (2 * length(coef(model))) / nrow(data), col = "red")
-    
+
     # Identificando pontos influentes
     influ_threshold_cook <- 4 / nrow(data)
     influ_threshold_leverage <- (2 * length(coef(model))) / nrow(data)
-    
+
     influente_cook <- which(diagnostics$cooksd > influ_threshold_cook)
     influente_leverage <- which(diagnostics$hat_values > influ_threshold_leverage)
     influentes <- unique(c(influente_cook, influente_leverage))
     diagnostics$influential_points <- influentes
-    
+
     # Plotando resíduos versus valores Ajustadas
     plot(model$fitted.values, resid(model),
          xlab = "Valores Ajustadas",
          ylab = "Resíduos",
          main = paste("Resíduos vs Ajustadas -", model_name))
     abline(h = 0, col = "red")
-    
+
   } else {
     # Analisando resíduos para modelos não lineares
     diagnostics$residuals <- residuals(model)
     diagnostics$fitted <- fitted(model)
-    
+
     # Resíduos padronizados
     res_padronizados <- diagnostics$residuals / sd(diagnostics$residuals)
-    
+
     # Plotando resíduos versus valores Ajustadas
     plot(diagnostics$fitted, diagnostics$residuals,
          xlab = "Valores Ajustadas",
          ylab = "Resíduos",
          main = paste("Resíduos vs Ajustadas -", model_name))
     abline(h = 0, col = "red")
-    
+
     # Histograma dos resíduos
     hist(diagnostics$residuals, main = paste("Histograma dos Resíduos -", model_name), xlab = "Resíduos")
-    
+
     # QQ-plot dos resíduos
     qqnorm(diagnostics$residuals, main = paste("QQ-Plot dos Resíduos -", model_name))
     qqline(diagnostics$residuals, col = "red")
-    
+
     # Identificando possíveis outliers
     possiveis_outliers <- which(abs(res_padronizados) > 2)
     diagnostics$possible_outliers <- possiveis_outliers
-    
+
     if (length(possiveis_outliers) > 0) {
       print(possiveis_outliers)
     }
   }
-  
+
   # Retornando os resultados do modelo e os diagnósticos
   list(model = model, diagnostics = diagnostics, model_type = model_type)
 }
@@ -170,7 +170,7 @@ calculate_model_metrics <- function(model, data, model_type) {
     r2_adj <- 1 - ((ss_res / (n - p)) / (ss_tot / (n - 1)))
     aic_val <- AIC(model)
   }
-  
+
   list(R_squared = r2, Adjusted_R_squared = r2_adj, AIC = aic_val)
 }
 
@@ -185,7 +185,7 @@ formula_linear <- AGB ~ Age
 linear_inicial <- run_regression_analysis(dados_linear, formula_linear, "Linear_Initial")
 if (!is.null(linear_inicial)) {
   metrics_linear_inicial <- calculate_model_metrics(linear_inicial$model, dados_linear, "Linear")
-  
+
   # Removendo pontos influentes e ajustando novamente, se necessário
   if (!is.null(linear_inicial$diagnostics$influential_points) && length(linear_inicial$diagnostics$influential_points) > 0) {
     dados_linear_Ajustada <- dados_linear[-linear_inicial$diagnostics$influential_points, ]
@@ -196,7 +196,7 @@ if (!is.null(linear_inicial)) {
     metrics_linear_Ajustada <- metrics_linear_inicial
     dados_linear_Ajustada <- dados_linear
   }
-  
+
   # Salvando os resultados
   results_list$Linear <- list(
     initial = list(model = linear_inicial$model, metrics = metrics_linear_inicial),
@@ -212,7 +212,7 @@ formula_multiplo <- AGB ~ Age + Temperature + Precipitation
 multiplo_inicial <- run_regression_analysis(dados_multiplo, formula_multiplo, "Multipla_Initial")
 if (!is.null(multiplo_inicial)) {
   metrics_multiplo_inicial <- calculate_model_metrics(multiplo_inicial$model, dados_multiplo, "Multipla")
-  
+
   # Removendo pontos influentes e ajustando novamente, se necessário
   if (!is.null(multiplo_inicial$diagnostics$influential_points) && length(multiplo_inicial$diagnostics$influential_points) > 0) {
     dados_multiplo_Ajustada <- dados_multiplo[-multiplo_inicial$diagnostics$influential_points, ]
@@ -223,7 +223,7 @@ if (!is.null(multiplo_inicial)) {
     metrics_multiplo_Ajustada <- metrics_multiplo_inicial
     dados_multiplo_Ajustada <- dados_multiplo
   }
-  
+
   # Salvando os resultados
   results_list$Multipla <- list(
     initial = list(model = multiplo_inicial$model, metrics = metrics_multiplo_inicial),
@@ -238,7 +238,7 @@ dados_gompertz <- na.omit(forest_data[, c("AGB", "Age")])
 gompertz_inicial <- run_regression_analysis(dados_gompertz, NULL, "Gompertz_Initial")
 if (!is.null(gompertz_inicial)) {
   metrics_gompertz_inicial <- calculate_model_metrics(gompertz_inicial$model, dados_gompertz, "Gompertz")
-  
+
   # Removendo possíveis outliers e ajustando novamente, se necessário
   if (!is.null(gompertz_inicial$diagnostics$possible_outliers) && length(gompertz_inicial$diagnostics$possible_outliers) > 0) {
     dados_gompertz_Ajustada <- dados_gompertz[-gompertz_inicial$diagnostics$possible_outliers, ]
@@ -249,7 +249,7 @@ if (!is.null(gompertz_inicial)) {
     metrics_gompertz_Ajustada <- metrics_gompertz_inicial
     dados_gompertz_Ajustada <- dados_gompertz
   }
-  
+
   # Salvando os resultados
   results_list$Gompertz <- list(
     initial = list(model = gompertz_inicial$model, metrics = metrics_gompertz_inicial),
@@ -264,7 +264,7 @@ dados_schnute <- na.omit(forest_data[, c("AGB", "Age")])
 schnute_inicial <- run_regression_analysis(dados_schnute, NULL, "Schnute_Initial")
 if (!is.null(schnute_inicial)) {
   metrics_schnute_inicial <- calculate_model_metrics(schnute_inicial$model, dados_schnute, "Schnute")
-  
+
   # Removendo possíveis outliers e ajustando novamente, se necessário
   if (!is.null(schnute_inicial$diagnostics$possible_outliers) && length(schnute_inicial$diagnostics$possible_outliers) > 0) {
     dados_schnute_Ajustada <- dados_schnute[-schnute_inicial$diagnostics$possible_outliers, ]
@@ -275,7 +275,7 @@ if (!is.null(schnute_inicial)) {
     metrics_schnute_Ajustada <- metrics_schnute_inicial
     dados_schnute_Ajustada <- dados_schnute
   }
-  
+
   # Salvando os resultados
   results_list$Schnute <- list(
     initial = list(model = schnute_inicial$model, metrics = metrics_schnute_inicial),
@@ -299,7 +299,7 @@ prepare_excel_data <- function(model_list, model_name) {
     )
     rbind(coef_df, metrics_df)
   }
-  
+
   list(
     initial = extract_info(model_list$initial),
     adjusted = extract_info(model_list$adjusted)
@@ -310,12 +310,12 @@ prepare_excel_data <- function(model_list, model_name) {
 excel_data <- list()
 for (modelo in names(results_list)) {
   dados_excel <- prepare_excel_data(results_list[[modelo]], modelo)
-  
+
   if (!is.null(dados_excel$initial)) {
     sheet_initial <- paste0(modelo, "_Initial")
     excel_data[[sheet_initial]] <- dados_excel$initial
   }
-  
+
   if (!is.null(dados_excel$adjusted)) {
     sheet_adjusted <- paste0(modelo, "_Adjusted")
     excel_data[[sheet_adjusted]] <- dados_excel$adjusted
@@ -338,15 +338,15 @@ predictions_df <- data.frame(Age = age_seq)
 # Loop para gerar previsões de cada modelo na 'results_list'
 for (model_name in names(results_list)) {
   model_info <- results_list[[model_name]] # Pegando as informações do modelo
-  
+
   for (version in names(model_info)) { # Iterando entre os modelos inicial e Ajustada
     version_info <- model_info[[version]]
-    
+
     # Verificando se o modelo atual está disponível
     if (!is.null(version_info)) {
       current_model <- version_info$model
       label <- paste(model_name, ifelse(version == "initial", "Inicial", "Ajustada"))
-      
+
       # Preparando novos dados para a previsão
       if (model_name == "Multipla") {
         # Para o modelo múltiplo, precisamos de Age, Temperature e Precipitation
@@ -361,7 +361,7 @@ for (model_name in names(results_list)) {
         # Para os outros modelos, só precisamos de Age
         newdata <- data.frame(Age = age_seq)
       }
-      
+
       # Gerando as previsões usando o modelo atual
       predictions <- tryCatch(
         predict(current_model, newdata = newdata),
@@ -370,7 +370,7 @@ for (model_name in names(results_list)) {
           return(rep(NA, length(age_seq)))
         }
       )
-      
+
       # Adicionando as previsões ao data frame
       predictions_df[[label]] <- predictions
     }
@@ -413,15 +413,15 @@ print(plot_combinado)
 # Gerando gráficos individuais para cada modelo (inicial e Ajustada)
 for (model_name in names(results_list)) {
   model_info <- results_list[[model_name]] # Pegando as informações do modelo
-  
+
   for (version in names(model_info)) { # Iterando entre versões inicial e ajustada
     version_info <- model_info[[version]]
-    
+
     # Verificando se o modelo atual está disponível
     if (!is.null(version_info)) {
       current_model <- version_info$model
       label <- paste(model_name, ifelse(version == "initial", "Inicial", "Ajustada"))
-      
+
       # Preparando novos dados para a previsão
       if (model_name == "Multipla") {
         # Para o modelo múltiplo, precisamos de Age, Temperature e Precipitation
@@ -436,7 +436,7 @@ for (model_name in names(results_list)) {
         # Para os outros modelos, só precisamos de Age
         newdata <- data.frame(Age = age_seq)
       }
-      
+
       # Gerando previsões
       predictions <- tryCatch(
         predict(current_model, newdata = newdata),
@@ -445,10 +445,10 @@ for (model_name in names(results_list)) {
           return(rep(NA, length(age_seq)))
         }
       )
-      
+
       # Preparando os dados para o gráfico individual
       plot_data <- data.frame(Age = age_seq, AGB_Previsto = predictions)
-      
+
       # Criando o gráfico individual
       p <- ggplot(forest_data, aes(x = Age, y = AGB)) +
         geom_point(alpha = 0.6, color = "grey40") + # Dados observados
@@ -465,7 +465,7 @@ for (model_name in names(results_list)) {
         ) +
         theme_minimal() +
         theme(plot.title = element_text(hjust = 0.5)) # Centralizando o título
-      
+
       # Mostrando o gráfico individual
       print(p)
     }

--- a/R/stepwise_regression_analysis.R
+++ b/R/stepwise_regression_analysis.R
@@ -1,4 +1,4 @@
-# Pacote fornece funções para ler dados em planilhas do Excel 
+# Pacote fornece funções para ler dados em planilhas do Excel
 library(readxl)
 
 # Definir diretório de dados e ler o arquivo
@@ -19,56 +19,56 @@ X2 <- dados$`Precipitação (mm)`
 cor(dados)
 
 #Entrando com o Modelo Nulo (Y = B0) e com o Modelo Completo (Y = B0+B1X1+B2X2)
-MN = lm(Y ~ 1, data=dados)
-MC = lm(Y ~ X1 + X2, data=dados)
+MN <- lm(Y ~ 1, data = dados)
+MC <- lm(Y ~ X1 + X2, data = dados)
 
 # Método: Passo a passo - "Stepwise", utilizando o critério AIC (k=2)
-step(MC, direction="both", k=2, trace=1)
-step(MN, scope=list(lower=MN,upper=MC), data = dados, direction="both", k=2, trace=1)
+step(MC, direction = "both", k = 2, trace = 1)
+step(MN, scope = list(lower = MN, upper = MC), data = dados, direction = "both", k = 2, trace = 1)
 
 # Regressão linear com modelo selecionado
-mod <- lm(Y~X1+X2)
+mod <- lm(Y ~ X1 + X2)
 anova(mod)
 summary(mod)
 
 # resíduos ordinários
-res_ord=residuals(mod);res_ord
+res_ord <- residuals(mod); res_ord
 
 # resíduos estudentizados internamente
-res_pad=rstandard(mod);res_pad
+res_pad <- rstandard(mod); res_pad
 
 # rs(i) - Resíduo estudentizado externamente
-res_stud=rstudent(mod);res_stud
+res_stud <- rstudent(mod); res_stud
 
 # matriz X e vetor Y
-X=model.matrix(mod);X
-Y=as.matrix(dados$`Captura(nº)`);Y
+X <- model.matrix(mod); X
+Y <- as.matrix(dados$`Captura(nº)`); Y
 
 # Pontos inconsistentes - rs(i) grande
 res_stud
-n=length(Y)
-p=ncol(X)
-alpha=0.05/(2*n)
-t_alpha=qt(alpha,n-p-1,lower.tail=F);t_alpha
+n <- length(Y)
+p <- ncol(X)
+alpha <- 0.05 / (2 * n)
+t_alpha <- qt(alpha, n - p - 1, lower.tail = FALSE); t_alpha
 
 # Pontos de alavanca
-H=X%*%solve(t(X)%*%X)%*%t(X)
-hii=diag(H);hii
-n=length(Y)
-p=ncol(X)
-hbarra=p/n
-pad_hii=(3*p)/n;pad_hii
+H <- X %*% solve(t(X) %*% X) %*% t(X)
+hii <- diag(H); hii
+n <- length(Y)
+p <- ncol(X)
+hbarra <- p / n
+pad_hii <- (3 * p) / n; pad_hii
 
 # Pontos influentes
-infl <- influence.measures(mod);infl
+infl <- influence.measures(mod); infl
 summary(infl)
 
 # Normalidade resíduos
-par(mfrow=c(2,2))
+par(mfrow = c(2, 2))
 plot(mod)
 residuos <- resid(mod)
 shapiro <- shapiro.test(residuos)
-print (shapiro)
+print(shapiro)
 
 # Homocedasticidade (Breusch-Pagan)
 library(lmtest)


### PR DESCRIPTION
## Summary
- Remove trailing whitespace across R analysis scripts
- Standardize assignment and spacing in stepwise regression script for readability

## Testing
- `Rscript -e 'lintr::lint_dir()'` *(fails: command not found)*
- `apt-get install -y r-base` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ad86c133f883319f874965149b639b