### PR TITLE
Add utility to load project libraries

### DIFF
--- a/functions/load_libraries.R
+++ b/functions/load_libraries.R
@@ -1,0 +1,19 @@
+load_libraries <- function() {
+  packages <- c(
+    "readxl",
+    "dplyr",
+    "writexl",
+    "MASS",
+    "car",
+    "ggplot2",
+    "tidyr",
+    "openxlsx",
+    "lmtest"
+  )
+  for (pkg in packages) {
+    if (!require(pkg, character.only = TRUE)) {
+      install.packages(pkg, dependencies = TRUE, repos = "https://cloud.r-project.org")
+      library(pkg, character.only = TRUE)
+    }
+  }
+}

--- a/process_data_and_run_regressions.R
+++ b/process_data_and_run_regressions.R
@@ -1,14 +1,8 @@
 # Main script for data processing and regression analysis
 
 # Load required libraries
-library(readxl)
-library(dplyr)
-library(writexl)
-library(MASS)
-library(car)
-library(ggplot2)
-library(tidyr)
-library(openxlsx)
+source(file.path("functions", "load_libraries.R"))
+load_libraries()
 
 # Build the unified dataset
 source(file.path("R", "merge_tables.R"))


### PR DESCRIPTION
## Summary
- create `load_libraries` function to centralize package loading
- update main analysis script to use the new helper

## Testing
- `Rscript process_data_and_run_regressions.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad889fcfe48331b5ebbd1596812d2f